### PR TITLE
Ticer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Experimental plugins:
   Stream your favorite radios in a playlist with HTML5 audio.
 * [Sublime](https://github.com/nashv/YellowBlogExtensions):
   Sublime Text 3 Extensions for blogs based on Yellow.
+* [Ticker](https://github.com/schulle4u/yellow-plugin-ticker): 
+  Feed parser using SimpleXML or SimplePie.
 * [Video](https://github.com/nibreh/yellow-plugin-video): 
   HTML5 video player.
 * [WebCLI](https://github.com/richi/yellow-plugin-cli):


### PR DESCRIPTION
Feed parser for yellow using PHP's SimpleXML functions, has optional support for [SimplePie](http://simplepie.org) in order to support atom feeds and caching. 